### PR TITLE
Update free_minishell + leak fix in exec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ C_DIR = src
 C_FILES = debug.c \
 	main.c \
 	free.c \
-	free2.c \
+	close.c \
 	exit.c \
 	error.c \
 	env/init.c \

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -94,7 +94,7 @@ void		put_error_va(char *fmt, va_list args);
 void		put_error(char *fmt, ...);
 
 /* Memory */
-void		free_minishell(t_minishell *minishell);
+void		free_minishell(t_minishell **minishell);
 void		free_token_lst(t_token **token_lst);
 t_envvar	*free_envvar_node(t_envvar **node);
 void		free_envvar_lst(t_envvar **var_lst);

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -94,7 +94,7 @@ void		put_error_va(char *fmt, va_list args);
 void		put_error(char *fmt, ...);
 
 /* Memory */
-void		free_minishell(t_minishell **minishell);
+void		free_minishell(t_minishell *minishell);
 void		free_token_lst(t_token **token_lst);
 t_envvar	*free_envvar_node(t_envvar **node);
 void		free_envvar_lst(t_envvar **var_lst);
@@ -102,7 +102,7 @@ void		free_cmd_lst(t_cmd **cmd_lst);
 void		flush_fds(void);
 
 /* Exit */
-void		exit_minishell(int exit_code, t_minishell **minishell,
+void		exit_minishell(int exit_code, t_minishell *minishell,
 				char *fmt, ...);
 
 /* Env */

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -99,6 +99,7 @@ void		free_token_lst(t_token **token_lst);
 t_envvar	*free_envvar_node(t_envvar **node);
 void		free_envvar_lst(t_envvar **var_lst);
 void		free_cmd_lst(t_cmd **cmd_lst);
+void		close_fd(int fd);
 void		flush_fds(void);
 
 /* Exit */

--- a/lib/libft/ft_matrix_size.c
+++ b/lib/libft/ft_matrix_size.c
@@ -21,6 +21,8 @@ size_t	ft_matrix_size(char **matrix)
 {
 	int	count;
 
+	if (!matrix || !*matrix)
+		return (0);
 	count = 0;
 	while (matrix[count])
 		count++;

--- a/src/close.c
+++ b/src/close.c
@@ -1,5 +1,11 @@
 #include "minishell.h"
 
+void	close_fd(int fd)
+{
+	if (fd > STDERR_FILENO)
+		close(fd);
+}
+
 /**
  * Close any fd up to FD_LIMIT, except standard ones.
  * 

--- a/src/cmd_list.c
+++ b/src/cmd_list.c
@@ -1,5 +1,4 @@
 #include "minishell.h"
-//#include "debug.h" //DEBUG
 
 /**
  * Creates a list of commands from the input string.
@@ -20,10 +19,9 @@ void	init_cmd_lst(char *input, t_minishell *minishell)
 
 	tokens = tokenizer(input);
 	if (!tokens)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	minishell->token_lst = tokens;
 	if (parse_tokens(minishell) == EXIT_FAILURE)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
-	//debug_tokens(minishell->token_lst); //DEBUG
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	free_token_lst(&minishell->token_lst);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -90,12 +90,17 @@ void	debug_cmd(t_cmd *cmd, char *label)
 	char *after = "\n";
 	ft_fprintf(o, "%sargs: ", before);
 	int	j = 0;
-	while (cmd->args[j] != NULL)
+	if (ft_matrix_size(cmd->args) <= 0)
+		ft_fprintf(o, "%s", NULL);
+	else
 	{
-		ft_fprintf(o, "%s", cmd->args[j]);
-		if (cmd->args[j + 1] != NULL)
-			ft_fprintf(o, ", ");
-		j++;
+		while (cmd->args[j] != NULL)
+		{
+			ft_fprintf(o, "%s", cmd->args[j]);
+			if (cmd->args[j + 1] != NULL)
+				ft_fprintf(o, ", ");
+			j++;
+		}
 	}
 	ft_fprintf(o, "%s", after);
 	ft_fprintf(o, "%sinfile: %s%s", before, cmd->infile, after);

--- a/src/env/path.c
+++ b/src/env/path.c
@@ -82,17 +82,17 @@ char	*get_exec_path(char *progname, t_minishell *minishell)
 	{
 		abspath = check_duplicate_abspath(progname);
 		if (abspath == NULL)
-			exit_minishell(E_CMDNOTEXEC, &minishell, progname);
+			exit_minishell(E_CMDNOTEXEC, minishell, progname);
 	}
 	else
 	{
 		dirnames = split_env_path(minishell);
 		if (dirnames == NULL)
-			exit_minishell(E_CMDNOTFOUND, &minishell, progname);
+			exit_minishell(E_CMDNOTFOUND, minishell, progname);
 		abspath = find_abspath(dirnames, progname);
 		ft_free_split(&dirnames);
 		if (abspath == NULL)
-			exit_minishell(E_CMDNOTFOUND, &minishell, progname);
+			exit_minishell(E_CMDNOTFOUND, minishell, progname);
 	}
 	return (abspath);
 }

--- a/src/execute.c
+++ b/src/execute.c
@@ -28,13 +28,13 @@ static void	setup_io(t_cmd *cmd, t_minishell *minishell)
 static void	cleanup_io(t_cmd *cmd)
 {
 	if (cmd->infile)
-		close(cmd->fdin);
+		close_fd(cmd->fdin);
 	if (cmd->outfile)
-		close(cmd->fdout);
+		close_fd(cmd->fdout);
 	if (cmd->next)
-		close(cmd->pipe[1]);
+		close_fd(cmd->pipe[1]);
 	if (cmd->prev)
-		close(cmd->prev->pipe[0]);
+		close_fd(cmd->prev->pipe[0]);
 }
 
 static void	duplicate_io(int newfd, int oldfd, t_minishell *minishell)
@@ -64,7 +64,7 @@ static void	execute_cmd(t_cmd *cmd, t_minishell *minishell)
 		exit_minishell(EXIT_FAILURE, minishell, exec_path);
 	}
 	waitpid(pid, &status, 0);
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+	if (WIFEXITED(status) && WEXITSTATUS(status) >= E_CMDNOTEXEC)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 }
 
@@ -75,9 +75,12 @@ void	execute_cmd_lst(t_minishell *minishell)
 	cmd = minishell->cmd_lst;
 	while (cmd)
 	{
-		setup_io(cmd, minishell);
-		execute_cmd(cmd, minishell);
-		cleanup_io(cmd);
+		if (ft_matrix_size(cmd->args) != 0)
+		{
+			setup_io(cmd, minishell);
+			execute_cmd(cmd, minishell);
+			cleanup_io(cmd);
+		}
 		cmd = cmd->next;
 	}
 }

--- a/src/execute.c
+++ b/src/execute.c
@@ -5,7 +5,7 @@ static void	setup_io(t_cmd *cmd, t_minishell *minishell)
 	if (cmd->next)
 	{
 		if (pipe(cmd->pipe) == -1)
-			exit_minishell(EXIT_FAILURE, &minishell, "pipe");
+			exit_minishell(EXIT_FAILURE, minishell, "pipe");
 	}
 	if (cmd->prev)
 		cmd->fdin = cmd->prev->pipe[0];
@@ -13,7 +13,7 @@ static void	setup_io(t_cmd *cmd, t_minishell *minishell)
 	{
 		cmd->fdin = open(cmd->infile, O_RDONLY);
 		if (cmd->fdin == -1)
-			exit_minishell(EXIT_FAILURE, &minishell, cmd->infile);
+			exit_minishell(EXIT_FAILURE, minishell, cmd->infile);
 	}
 	if (cmd->next)
 		cmd->fdout = cmd->pipe[1];
@@ -21,7 +21,7 @@ static void	setup_io(t_cmd *cmd, t_minishell *minishell)
 	{
 		cmd->fdout = open(cmd->outfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 		if (cmd->fdout == -1)
-			exit_minishell(EXIT_FAILURE, &minishell, cmd->outfile);
+			exit_minishell(EXIT_FAILURE, minishell, cmd->outfile);
 	}
 }
 
@@ -40,7 +40,7 @@ static void	cleanup_io(t_cmd *cmd)
 static void	duplicate_io(int newfd, int oldfd, t_minishell *minishell)
 {
 	if (dup2(newfd, oldfd) == -1)
-		exit_minishell(EXIT_FAILURE, &minishell, "dup2");
+		exit_minishell(EXIT_FAILURE, minishell, "dup2");
 	close(newfd);
 }
 
@@ -52,7 +52,7 @@ static void	execute_cmd(t_cmd *cmd, t_minishell *minishell)
 
 	pid = fork();
 	if (pid < 0)
-		exit_minishell(EXIT_FAILURE, &minishell, "fork");
+		exit_minishell(EXIT_FAILURE, minishell, "fork");
 	if (pid == 0)
 	{
 		if (cmd->fdin != STDIN_FILENO)
@@ -61,11 +61,11 @@ static void	execute_cmd(t_cmd *cmd, t_minishell *minishell)
 			duplicate_io(cmd->fdout, STDOUT_FILENO, minishell);
 		exec_path = get_exec_path(cmd->args[0], minishell);
 		execve(exec_path, cmd->args, minishell->envp);
-		exit_minishell(EXIT_FAILURE, &minishell, exec_path);
+		exit_minishell(EXIT_FAILURE, minishell, exec_path);
 	}
 	waitpid(pid, &status, 0);
 	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 }
 
 void	execute_cmd_lst(t_minishell *minishell)

--- a/src/exit.c
+++ b/src/exit.c
@@ -11,7 +11,7 @@
  * @param fmt Format for the error message to print on stderr
  * @param ... Variadic list of values to expend in fmt
  */
-void	exit_minishell(int exit_code, t_minishell **minishell, char *fmt, ...)
+void	exit_minishell(int exit_code, t_minishell *minishell, char *fmt, ...)
 {
 	va_list	args;
 

--- a/src/exit.c
+++ b/src/exit.c
@@ -17,6 +17,6 @@ void	exit_minishell(int exit_code, t_minishell *minishell, char *fmt, ...)
 
 	va_start(args, fmt);
 	put_error_va(fmt, args);
-	free_minishell(minishell);
+	free_minishell(&minishell);
 	exit(exit_code % 256);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -94,14 +94,14 @@ void	free_cmd_lst(t_cmd **cmd_lst)
  * 	including lists of t_cmd, t_envvar, etc.
  * @return void
  */
-void	free_minishell(t_minishell *minishell)
+void	free_minishell(t_minishell **minishell)
 {
-	if (minishell->envvar_lst)
-		free_envvar_lst(&minishell->envvar_lst);
-	if (minishell->token_lst)
-		free_token_lst(&minishell->token_lst);
-	if (minishell->cmd_lst)
-		free_cmd_lst(&minishell->cmd_lst);
-	ft_free_split(&minishell->envp);
-	ft_free_ptrs(1, &minishell);
+	if ((*minishell)->envvar_lst)
+		free_envvar_lst(&(*minishell)->envvar_lst);
+	if ((*minishell)->token_lst)
+		free_token_lst(&(*minishell)->token_lst);
+	if ((*minishell)->cmd_lst)
+		free_cmd_lst(&(*minishell)->cmd_lst);
+	ft_free_split(&(*minishell)->envp);
+	ft_free_ptrs(1, minishell);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -94,14 +94,14 @@ void	free_cmd_lst(t_cmd **cmd_lst)
  * 	including lists of t_cmd, t_envvar, etc.
  * @return void
  */
-void	free_minishell(t_minishell **minishell)
+void	free_minishell(t_minishell *minishell)
 {
-	if ((*minishell)->envvar_lst)
-		free_envvar_lst(&(*minishell)->envvar_lst);
-	if ((*minishell)->token_lst)
-		free_token_lst(&(*minishell)->token_lst);
-	if ((*minishell)->cmd_lst)
-		free_cmd_lst(&(*minishell)->cmd_lst);
-	ft_free_split(&(*minishell)->envp);
-	ft_free_ptrs(1, minishell);
+	if (minishell->envvar_lst)
+		free_envvar_lst(&minishell->envvar_lst);
+	if (minishell->token_lst)
+		free_token_lst(&minishell->token_lst);
+	if (minishell->cmd_lst)
+		free_cmd_lst(&minishell->cmd_lst);
+	ft_free_split(&minishell->envp);
+	ft_free_ptrs(1, &minishell);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -19,10 +19,10 @@ static	t_minishell	*init_minishell(char **envp)
 	minishell->cmd_lst = NULL;
 	minishell->envp = ft_matrix_dup(envp);
 	if (!minishell->envp)
-		exit_minishell(EXIT_FAILURE, &minishell, "failed to copy environment");
+		exit_minishell(EXIT_FAILURE, minishell, "failed to copy environment");
 	minishell->envvar_lst = init_envvars(minishell);
 	if (!minishell->envvar_lst)
-		exit_minishell(EXIT_FAILURE, &minishell,
+		exit_minishell(EXIT_FAILURE, minishell,
 			"failed to initialize environment variables");
 	return (minishell);
 }
@@ -46,11 +46,11 @@ int	main(int ac, char **av, char **envp)
 	minishell = init_minishell(envp);
 	//debug_envp(minishell->envp); //DEBUG
 	//debug_envvars(minishell->envvar_lst); //DEBUG
-	input = "''";
+	input = "";
 	//input = "<test/infile tail -n +4 | grep a | sort | uniq -c | sort -nr | head -n 3";
 	init_cmd_lst(input, minishell);
 	debug_cmd_lst(minishell->cmd_lst); //DEBUG
 	execute_cmd_lst(minishell);
-	free_minishell(&minishell);
+	free_minishell(minishell);
 	return (EXIT_SUCCESS);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 #include "minishell.h"
-#include "debug.h" //DEBUG
 
 /**
  * Inititalize the t_minishell struct containing global data on the program.
@@ -44,12 +43,8 @@ int	main(int ac, char **av, char **envp)
 	if (ac > 1)
 		return (EXIT_FAILURE); //TODO Deal with non-interactive mode
 	minishell = init_minishell(envp);
-	//debug_envp(minishell->envp); //DEBUG
-	//debug_envvars(minishell->envvar_lst); //DEBUG
-	input = "";
-	//input = "<test/infile tail -n +4 | grep a | sort | uniq -c | sort -nr | head -n 3";
+	input = "| tail -n +4 | grep a | sort | uniq -c | sort -nr | head -n 3";
 	init_cmd_lst(input, minishell);
-	debug_cmd_lst(minishell->cmd_lst); //DEBUG
 	execute_cmd_lst(minishell);
 	free_minishell(minishell);
 	return (EXIT_SUCCESS);

--- a/src/main.c
+++ b/src/main.c
@@ -43,9 +43,9 @@ int	main(int ac, char **av, char **envp)
 	if (ac > 1)
 		return (EXIT_FAILURE); //TODO Deal with non-interactive mode
 	minishell = init_minishell(envp);
-	input = "| tail -n +4 | grep a | sort | uniq -c | sort -nr | head -n 3";
+	input = "<test/infile tail -n +4 | grep a | sort | uniq -c | sort -nr | head -n 3";
 	init_cmd_lst(input, minishell);
 	execute_cmd_lst(minishell);
-	free_minishell(minishell);
+	free_minishell(&minishell);
 	return (EXIT_SUCCESS);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -21,6 +21,7 @@ t_cmd	*cmd_new(t_cmd *prev_cmd)
 	cmd->pipe[1] = -1;
 	cmd->fdin = STDIN_FILENO;
 	cmd->fdout = STDOUT_FILENO;
+	cmd->pid = -1;
 	cmd->prev = prev_cmd;
 	cmd->next = NULL;
 	if (cmd->prev)
@@ -73,7 +74,7 @@ int	parse_tokens(t_minishell *minishell)
 		return (EXIT_FAILURE);
 	minishell->cmd_lst = cmd_new(NULL);
 	if (!minishell->cmd_lst)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	cur_token = minishell->token_lst;
 	cur_cmd = minishell->cmd_lst;
 	while (cur_token)

--- a/src/token_handlers.c
+++ b/src/token_handlers.c
@@ -10,11 +10,11 @@ void	handle_pipe(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	if (!(*cur_token)->next || (*cur_token)->next->type == TOKEN_PIPE)
-		exit_minishell(EXIT_FAILURE, &minishell,
+		exit_minishell(EXIT_FAILURE, minishell,
 			"syntax error near unexpected token `|'");
 	(*cur_cmd)->next = cmd_new((*cur_cmd));
 	if (!(*cur_cmd)->next)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_cmd) = (*cur_cmd)->next;
 }
 
@@ -29,12 +29,12 @@ void	handle_input_redirection(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	if (!(*cur_token)->next || (*cur_token)->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, &minishell,
+		exit_minishell(EXIT_FAILURE, minishell,
 			"syntax error near unexpected token `newline'");
 	ft_free_ptrs(1, &(*cur_cmd)->infile);
 	(*cur_cmd)->infile = ft_strdup((*cur_token)->next->value);
 	if (!(*cur_cmd)->infile)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_token) = (*cur_token)->next;
 }
 
@@ -49,12 +49,12 @@ void	handle_output_redirection(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	if (!(*cur_token)->next || (*cur_token)->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, &minishell,
+		exit_minishell(EXIT_FAILURE, minishell,
 			"syntax error near unexpected token `newline'");
 	ft_free_ptrs(1, &(*cur_cmd)->outfile);
 	(*cur_cmd)->outfile = ft_strdup((*cur_token)->next->value);
 	if (!(*cur_cmd)->outfile)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_token) = (*cur_token)->next;
 }
 
@@ -71,6 +71,6 @@ void	handle_word(t_token **cur_token, t_cmd **cur_cmd,
 
 	arg_copy = ft_strdup((*cur_token)->value);
 	if (!arg_copy)
-		exit_minishell(EXIT_FAILURE, &minishell, NULL);
+		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	add_arg_to_cmd(*cur_cmd, arg_copy);
 }


### PR DESCRIPTION
- Updated signature for `exit_minishell`: `t_minishell **minishell` => `t_minishell *minishell`
- Tried to fix leaks issue in execute.c when cmd->args is NULL