### PR TITLE
Fix - Empty command

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -8,6 +8,7 @@
 # include <readline/readline.h>
 # include <readline/history.h>
 # include <sys/wait.h>
+# include <sys/stat.h> 
 
 /****************************************/
 /* Macros and Enums                     */
@@ -95,7 +96,6 @@ typedef struct s_builtin
 {
 	char	*name;
 	int		(*fn)(char **args, t_minishell *minishell);
-	int		affects_state;
 }	t_builtin;
 
 /****************************************/
@@ -124,6 +124,7 @@ void			exit_minishell(int exit_code, t_minishell *minishell, char *fmt, ...);
 /* Env */
 char			*get_env_value(char *var_name, t_minishell *minishell);
 t_envvar		*init_envvars(t_minishell *minishell);
+t_bool			is_directory(char *path);
 t_bool			is_path(char *s);
 int				update_envp(t_minishell *minishell);
 t_envvar		*envvar_new(char *var);

--- a/src/debug.c
+++ b/src/debug.c
@@ -89,8 +89,7 @@ void	debug_cmd(t_cmd *cmd, char *label)
 	after = "\n";
 	ft_fprintf(o, "%sargs: ", before);
 	i = 0;
-	if (cmd->args != NULL && cmd->args[0] != NULL
-		&& ft_strlen(cmd->args[0]) != 0)
+	if (cmd->args != NULL && cmd->args[0] != NULL)
 	{
 		while (cmd->args[i] != NULL)
 		{

--- a/src/env/utils.c
+++ b/src/env/utils.c
@@ -25,6 +25,25 @@ t_bool	is_path(char *s)
 }
 
 /**
+ * Checks if a path matches with an existing directory.
+ * 
+ * @param s The path to check. If `NULL` or empty, returns `FALSE`.
+ * @return t_bool `TRUE` if the path is a valid directory.
+ */
+t_bool	is_directory(char *path)
+{
+	struct stat	path_stat;
+	int			res;
+
+	if (!path || path[0] == '\0')
+		return (FALSE);
+	res = stat(path, &path_stat);
+	if (res == 0 && S_ISDIR(path_stat.st_mode))
+		return (TRUE);
+	return (FALSE);
+}
+
+/**
  * Get the value of an environment variable from its name.
  * 
  * This function is searching through the member

--- a/src/execute/builtins.c
+++ b/src/execute/builtins.c
@@ -9,24 +9,24 @@
 t_builtin	*get_builtin(char *progname)
 {
 	static t_builtin	builtins[] = {
-	{"echo", do_echo, FALSE},
-	{"cd", do_cd, TRUE},
-	{"pwd", do_pwd, FALSE},
-	{"export", do_export, TRUE},
-	{"unset", do_unset, TRUE},
-	{"env", do_env, FALSE},
-	{"exit", do_exit, TRUE}
+	{"echo", do_echo},
+	{"cd", do_cd},
+	{"pwd", do_pwd},
+	{"export", do_export},
+	{"unset", do_unset},
+	{"env", do_env},
+	{"exit", do_exit}
 	};
 	size_t				lst_size;
 	size_t				progname_len;
 	size_t				i;
 
-	lst_size = sizeof(builtins) / sizeof(builtins[0]);
 	progname_len = ft_strlen(progname);
+	lst_size = sizeof(builtins) / sizeof(builtins[0]);
 	i = 0;
 	while (i < lst_size)
 	{
-		if (ft_strncmp(builtins[i].name, progname, progname_len) == 0)
+		if (ft_strncmp(builtins[i].name, progname, progname_len + 1) == 0)
 			return (&builtins[i]);
 		i++;
 	}

--- a/src/execute/parent_process.c
+++ b/src/execute/parent_process.c
@@ -110,17 +110,17 @@ static void	execute_cmd(t_cmd *cmd, t_minishell *ms)
 {
 	t_builtin	*builtin;
 
-	if (cmd->args && cmd->args[0] && cmd->args[0][0] != '\0')
+	if (cmd->args)
 	{
 		if (setup_io(cmd, ms) == EXIT_FAILURE)
 			ms->exit_code = EXIT_FAILURE;
 		else
 		{
 			builtin = get_builtin(cmd->args[0]);
-			if (builtin && builtin->affects_state && !cmd->next && !cmd->prev)
-				run_builtin(FALSE, builtin, cmd->args, ms);
-			else
+			if (cmd->prev || cmd->next || !builtin)
 				cmd->pid = run_in_child_process(builtin, cmd, ms);
+			else
+				run_builtin(FALSE, builtin, cmd->args, ms);
 			cleanup_io(cmd);
 		}
 	}


### PR DESCRIPTION
Fixes:
- When an empty cmd is executed: display error "minishell: : command not found"
- When a valid directory is executed: display error "minishell: <dir>: Is a directory"
- Allowed builtins that don't change state to be executed in parent process if there is no pipe around them in the command (before, they were always ran in subprocess, which is useless)
- The previous point led to remove the now useless member "affects_state" of t_builtin
