### PR TITLE
Fix empty command exiting minishell

### DIFF
--- a/src/cmd_list.c
+++ b/src/cmd_list.c
@@ -20,7 +20,7 @@ void	init_cmd_lst(t_minishell *minishell)
 	tokens = tokenizer(minishell);
 	ft_free_ptrs(1, &minishell->input);
 	if (!tokens)
-		exit_minishell(EXIT_FAILURE, minishell, NULL);
+		return ;
 	minishell->token_lst = tokens;
 	if (parse_tokens(minishell) == EXIT_FAILURE)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -105,8 +105,10 @@ int	main(int ac, char **av, char **envp)
 	minishell = init_minishell(envp);
 	while (1)
 	{
-		set_input(minishell);
+		set_input(minishell);	
 		init_cmd_lst(minishell);
+		if (minishell->cmd_lst == NULL)
+			continue ;
 		execute_cmd_lst(minishell);
 		free_cmd_lst(&minishell->cmd_lst);
 	}


### PR DESCRIPTION
Fixed the empty command issue: 
- before, it was exiting minishell completly (incorrect behaviour)
- After this fix, minishell just displays a new prompt on a new line, like bash does.