### PR TITLE
Fix redir errors

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -94,7 +94,7 @@ typedef struct s_tokenize_op
 typedef struct s_parse_op
 {
 	int		type;
-	void	(*handler)(t_token **, t_cmd **, t_minishell *);
+	int		(*handler)(t_token **, t_cmd **, t_minishell *);
 }	t_parse_op;
 
 typedef struct s_builtin
@@ -140,23 +140,24 @@ void			init_cmd_lst(t_minishell *minishell);
 t_cmd			*cmd_new(t_cmd *prev_cmd);
 void			add_arg_to_cmd(t_cmd *cmd, char *arg);
 int				parse_tokens(t_minishell *minishell);
+char			*redir_error(t_token *token);
 t_parse_op		*get_parse_ops(void);
 int				process_heredoc(t_cmd *cmd);
 int				process_all_heredocs(t_minishell *ms);
 void			cleanup_heredoc(t_minishell *ms);
-void			handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_redir_in(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_redir_in(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_redir_out(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_redir_out(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_word(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_word(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_pipe(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_pipe(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_redir_heredoc(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_redir_heredoc(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
-void			handle_redir_append(t_token **cur_token, t_cmd **cur_cmd,
+int				handle_redir_append(t_token **cur_token, t_cmd **cur_cmd,
 					t_minishell *minishell);
 
 /* Tokenization */

--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -64,6 +64,7 @@ typedef struct s_cmd
 	char			*outfile;
 	char			*heredoc_del;
 	char			*heredoc_tmpfile;
+	int				heredoc_start;
 	int				append;
 	int				*pipe;
 	int				saved_stdin;
@@ -83,6 +84,7 @@ typedef struct s_minishell
 	t_token		*token_lst;
 	t_cmd		*cmd_lst;
 	int			exit_code;
+	int			input_line;
 }	t_minishell;
 
 typedef struct s_tokenize_op

--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,1 @@
+test && cat output.txt

--- a/output.txt
+++ b/output.txt
@@ -1,1 +1,0 @@
-test && cat output.txt

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@ t_minishell	*init_minishell(char **envp)
 	minishell->token_lst = NULL;
 	minishell->cmd_lst = NULL;
 	minishell->exit_code = 0;
+	minishell->input_line = 0;
 	minishell->envp = ft_matrix_dup(envp);
 	if (!minishell->envp)
 		exit_minishell(E_CRITICAL, minishell, "failed to copy environment");
@@ -75,6 +76,7 @@ static void	set_input(t_minishell *minishell)
 {
 	set_errno(EXIT_SUCCESS);
 	minishell->input = readline("minishell$ ");
+	minishell->input_line++;
 	if (!minishell->input)
 	{
 		if (errno != EXIT_SUCCESS)
@@ -105,7 +107,7 @@ int	main(int ac, char **av, char **envp)
 	minishell = init_minishell(envp);
 	while (1)
 	{
-		set_input(minishell);	
+		set_input(minishell);
 		init_cmd_lst(minishell);
 		if (minishell->cmd_lst == NULL)
 			continue ;

--- a/src/parser/cmd_utils.c
+++ b/src/parser/cmd_utils.c
@@ -8,6 +8,7 @@ static void	init_cmd_redir(t_cmd *cmd)
 	cmd->outfile = NULL;
 	cmd->heredoc_del = NULL;
 	cmd->heredoc_tmpfile = NULL;
+	cmd->heredoc_start = 0;
 	cmd->append = 0;
 }
 

--- a/src/parser/handlers/handle_pipe.c
+++ b/src/parser/handlers/handle_pipe.c
@@ -1,5 +1,12 @@
 #include "minishell.h"
-
+/**
+ * Determines the error message for invalid pipe syntax.
+ * 
+ * @param token Current token being processed.
+ * @return "|" if the next token is missing or another pipe, otherwise returns
+ *         the unexpected token's value.
+ * @note Static helper for `handle_pipe`.
+ */
 static char	*pipe_error(t_token *token)
 {
 	if (!token->next)

--- a/src/parser/handlers/handle_pipe.c
+++ b/src/parser/handlers/handle_pipe.c
@@ -1,4 +1,14 @@
 #include "minishell.h"
+
+static char	*pipe_error(t_token *token)
+{
+	if (!token->next)
+		return ("|");
+	if (token->next->type == TOKEN_PIPE)
+		return ("|");
+	return (token->next->value);
+}
+
 /**
  * Handles the pipe (`|`) token by creating a new command.
  * - Checks for syntax errors like consecutive pipes.
@@ -6,18 +16,23 @@
  * @TODO Check malloc error message (for now on NULL)
  * 
  */
-void	handle_pipe(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_pipe(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
 
 	token = *cur_token;
 	if (!(token)->next || token->next->type == TOKEN_PIPE)
-		exit_minishell(EXIT_FAILURE, minishell,
-			"syntax error near unexpected token `|'");
+	{
+		put_error("syntax error near unexpected token `%s'",
+			pipe_error(token));
+		minishell->exit_code = E_CRITICAL;
+		return (EXIT_FAILURE);
+	}
 	(*cur_cmd)->next = cmd_new((*cur_cmd));
 	if (!(*cur_cmd)->next)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_cmd) = (*cur_cmd)->next;
 	*cur_token = token->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_redir_append.c
+++ b/src/parser/handlers/handle_redir_append.c
@@ -7,19 +7,24 @@
  * If the token sequence is invalid, it exits with a syntax error.
  * @TODO Check malloc error message (for now on NULL)
  */
-void	handle_redir_append(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_redir_append(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
 
 	token = *cur_token;
 	if (!token->next || token->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, minishell,
-			"syntax error near unexpected token `newline'");
+	{
+		put_error("syntax error near unexpected token `%s'",
+			redir_error(token));
+		minishell->exit_code = E_CRITICAL;
+		return (EXIT_FAILURE);
+	}
 	ft_free(1, &(*cur_cmd)->outfile);
 	(*cur_cmd)->outfile = ft_strdup(token->next->value);
 	(*cur_cmd)->append = 1;
 	if (!(*cur_cmd)->outfile)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	*cur_token = token->next->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_redir_heredoc.c
+++ b/src/parser/handlers/handle_redir_heredoc.c
@@ -26,5 +26,6 @@ int	handle_redir_heredoc(t_token **cur_token, t_cmd **cur_cmd,
 	if (!(*cur_cmd)->heredoc_del)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	*cur_token = token->next->next;
+	(*cur_cmd)->heredoc_start = minishell->input_line;
 	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_redir_heredoc.c
+++ b/src/parser/handlers/handle_redir_heredoc.c
@@ -7,19 +7,24 @@
  * If the token sequence is invalid, it exits with a syntax error.
  * @TODO Check malloc error message (for now on NULL)
  */
-void	handle_redir_heredoc(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_redir_heredoc(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
 
 	token = *cur_token;
 	if (!token->next || token->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, minishell,
-			"syntax error near unexpected token `newline'");
+	{
+		put_error("syntax error near unexpected token `%s'",
+			redir_error(token));
+		minishell->exit_code = E_CRITICAL;
+		return (EXIT_FAILURE);
+	}
 	ft_free(1, &(*cur_cmd)->infile);
 	ft_free(1, &(*cur_cmd)->heredoc_del);
 	(*cur_cmd)->heredoc_del = ft_strdup(token->next->value);
 	if (!(*cur_cmd)->heredoc_del)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	*cur_token = token->next->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_redir_in.c
+++ b/src/parser/handlers/handle_redir_in.c
@@ -6,18 +6,23 @@
  * - Copies the file name to the current command's infile field.
  * @TODO Check malloc error message (for now on NULL)
  */
-void	handle_redir_in(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_redir_in(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
 
 	token = *cur_token;
 	if (!token->next || token->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, minishell,
-			"syntax error near unexpected token `newline'");
+	{
+		put_error("syntax error near unexpected token `%s'",
+			redir_error(token));
+		minishell->exit_code = E_CRITICAL;
+		return (EXIT_FAILURE);
+	}
 	ft_free(1, &(*cur_cmd)->infile);
 	(*cur_cmd)->infile = ft_strdup(token->next->value);
 	if (!(*cur_cmd)->infile)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_token) = token->next->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_redir_out.c
+++ b/src/parser/handlers/handle_redir_out.c
@@ -6,19 +6,24 @@
  * - Copies the file name to the current command's outfile field.
  * @TODO Check malloc error message (for now on NULL)
  */
-void	handle_redir_out(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_redir_out(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
 
 	token = *cur_token;
 	if (!token->next || token->next->type != TOKEN_WORD)
-		exit_minishell(EXIT_FAILURE, minishell,
-			"syntax error near unexpected token `newline'");
+	{
+		put_error("syntax error near unexpected token `%s'",
+			redir_error(token));
+		minishell->exit_code = E_CRITICAL;
+		return (EXIT_FAILURE);
+	}
 	ft_free(1, &(*cur_cmd)->outfile);
 	(*cur_cmd)->outfile = ft_strdup(token->next->value);
 	(*cur_cmd)->append = 0;
 	if (!(*cur_cmd)->outfile)
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	(*cur_token) = token->next->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/handlers/handle_word.c
+++ b/src/parser/handlers/handle_word.c
@@ -5,7 +5,7 @@
  * - Duplicates the word and adds it to the args list of the current command.
  * @TODO Check malloc error message (for now on NULL)
  */
-void	handle_word(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_word(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_token	*token;
@@ -17,4 +17,5 @@ void	handle_word(t_token **cur_token, t_cmd **cur_cmd,
 		exit_minishell(EXIT_FAILURE, minishell, NULL);
 	add_arg_to_cmd(*cur_cmd, arg_copy);
 	*cur_token = token->next;
+	return (EXIT_SUCCESS);
 }

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -99,14 +99,13 @@ int	process_heredoc(t_cmd *cmd)
 	read_heredoc(tmp_fd, cmd);
 	ft_close(&tmp_fd);
 	if (!cmd->heredoc_del || ft_strcmp(cmd->heredoc_del, "") == 0)
-		return (unlink(tmp_file), EXIT_FAILURE);
+		return (unlink(tmp_file), ft_free(1, &cmd->heredoc_del), EXIT_FAILURE);
 	cmd->infile = ft_strdup(tmp_file);
 	cmd->heredoc_tmpfile = ft_strdup(tmp_file);
 	if (!cmd->infile || !cmd->heredoc_tmpfile)
 	{
 		unlink(tmp_file);
-		free(cmd->infile);
-		free(cmd->heredoc_tmpfile);
+		ft_free(2, &cmd->infile, &cmd->heredoc_tmpfile);
 		cmd->infile = NULL;
 		cmd->heredoc_tmpfile = NULL;
 		return (EXIT_FAILURE);
@@ -155,7 +154,7 @@ void	cleanup_heredoc(t_minishell *ms)
 		if (cmd->heredoc_tmpfile)
 		{
 			unlink(cmd->heredoc_tmpfile);
-			free(cmd->heredoc_tmpfile);
+			ft_free(1, &cmd->heredoc_tmpfile);
 			cmd->heredoc_tmpfile = NULL;
 		}
 		cmd = cmd->next;

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -43,6 +43,8 @@ static int	generate_unique_file(char *tmp_file)
  * Continuously reads input from the user until the heredoc delimiter 
  * (cmd->heredoc_del) is encountered. Each input line is written to the 
  * temporary file. If the delimiter is encountered, input stops.
+ * - If CTRL + D is pressed during the heredoc input process, the 
+ * 	program will return an error.
  * 
  * @param tmp_fd File descriptor for the temporary heredoc file.
  * @param cmd Pointer to the command struct containing the heredoc delimiter.
@@ -56,7 +58,13 @@ static int	read_heredoc(int tmp_fd, t_cmd *cmd)
 	{
 		line = readline("> ");
 		if (!line)
+		{
+			set_errno(0);
+			put_error("warning: here-document at line %d delimited by "
+				"end of file (wanted `%s')", cmd->heredoc_start,
+				cmd->heredoc_del);
 			break ;
+		}
 		if (ft_strcmp(line, cmd->heredoc_del) == 0)
 		{
 			free(line);
@@ -90,6 +98,8 @@ int	process_heredoc(t_cmd *cmd)
 		return (EXIT_FAILURE);
 	read_heredoc(tmp_fd, cmd);
 	ft_close(&tmp_fd);
+	if (!cmd->heredoc_del || ft_strcmp(cmd->heredoc_del, "") == 0)
+		return (unlink(tmp_file), EXIT_FAILURE);
 	cmd->infile = ft_strdup(tmp_file);
 	cmd->heredoc_tmpfile = ft_strdup(tmp_file);
 	if (!cmd->infile || !cmd->heredoc_tmpfile)

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -27,7 +27,7 @@ static int	generate_unique_file(char *tmp_file)
 		base = "/tmp/minishell_heredoc_";
 		ft_strlcpy(tmp_file, base, 256);
 		ft_strlcat(tmp_file, num_str, 256);
-		ft_free(num_str);
+		ft_free(1, &num_str);
 		if (access(tmp_file, F_OK) == -1)
 		{
 			fd = open(tmp_file, O_WRONLY | O_CREAT | O_EXCL, 0600);

--- a/src/parser/heredoc.c
+++ b/src/parser/heredoc.c
@@ -27,7 +27,7 @@ static int	generate_unique_file(char *tmp_file)
 		base = "/tmp/minishell_heredoc_";
 		ft_strlcpy(tmp_file, base, 256);
 		ft_strlcat(tmp_file, num_str, 256);
-		ft_free(1, &num_str);
+		ft_free(num_str);
 		if (access(tmp_file, F_OK) == -1)
 		{
 			fd = open(tmp_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
@@ -55,14 +55,16 @@ static int	read_heredoc(int tmp_fd, t_cmd *cmd)
 	while (1)
 	{
 		line = readline("> ");
+		if (!line)
+			break ;
 		if (ft_strcmp(line, cmd->heredoc_del) == 0)
 		{
-			ft_free(1, &line);
+			free(line);
 			break ;
 		}
 		write(tmp_fd, line, ft_strlen(line));
 		write(tmp_fd, "\n", 1);
-		ft_free(1, &line);
+		free(line);
 	}
 	return (EXIT_SUCCESS);
 }
@@ -93,8 +95,8 @@ int	process_heredoc(t_cmd *cmd)
 	if (!cmd->infile || !cmd->heredoc_tmpfile)
 	{
 		unlink(tmp_file);
-		ft_free(1, &cmd->infile);
-		ft_free(1, &cmd->heredoc_tmpfile);
+		free(cmd->infile);
+		free(cmd->heredoc_tmpfile);
 		cmd->infile = NULL;
 		cmd->heredoc_tmpfile = NULL;
 		return (EXIT_FAILURE);
@@ -143,7 +145,7 @@ void	cleanup_heredoc(t_minishell *ms)
 		if (cmd->heredoc_tmpfile)
 		{
 			unlink(cmd->heredoc_tmpfile);
-			ft_free(1, &cmd->heredoc_tmpfile);
+			free(cmd->heredoc_tmpfile);
 			cmd->heredoc_tmpfile = NULL;
 		}
 		cmd = cmd->next;

--- a/src/parser/init_cmd_list.c
+++ b/src/parser/init_cmd_list.c
@@ -23,6 +23,10 @@ void	init_cmd_lst(t_minishell *minishell)
 		return ;
 	minishell->token_lst = tokens;
 	if (parse_tokens(minishell) == EXIT_FAILURE)
-		exit_minishell(EXIT_FAILURE, minishell, NULL);
-	free_token_lst(&minishell->token_lst);
+	{
+		free_token_lst(&minishell->token_lst);
+		minishell->cmd_lst = NULL;
+	}
+	else
+		free_token_lst(&minishell->token_lst);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,5 +1,12 @@
 #include "minishell.h"
-
+/**
+ * Cleans up token and command lists if parsing fails.
+ * 
+ * @param minishell Shell instance containing token/cmd lists.
+ * @param status Indicates failure (EXIT_FAILURE) or success.
+ * @return The input `status` unchanged.
+ * @note Frees resources only on failure (EXIT_FAILURE).
+ */
 static int	parse_cleanup(t_minishell *minishell, int status)
 {
 	if (status == EXIT_FAILURE)
@@ -14,7 +21,7 @@ static int	parse_cleanup(t_minishell *minishell, int status)
  * Parses a list of tokens and builds a linked list of commands.
  *
  * - Initializes the command list (`cmd_lst`).
- * - Iterates through tokens, processing each one using `handle_token_type()`.
+ * - Delegates token processing to `handle_token_type`.
  * - Exits if an error occurs.
  * 
  * Returns: EXIT_SUCCESS on success, or EXIT_FAILURE on failure.
@@ -36,10 +43,9 @@ int	parse_tokens(t_minishell *minishell)
 		prev_token = cur_token;
 		if (handle_token_type(&cur_token, &cur_cmd, minishell)
 			== EXIT_FAILURE)
-		return (parse_cleanup(minishell, EXIT_FAILURE));
+			return (parse_cleanup(minishell, EXIT_FAILURE));
 		if (cur_token == prev_token)
 			exit_minishell(EXIT_FAILURE, minishell, NULL);
-
 	}
 	return (EXIT_SUCCESS);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,4 +1,15 @@
 #include "minishell.h"
+
+static int	parse_cleanup(t_minishell *minishell, int status)
+{
+	if (status == EXIT_FAILURE)
+	{
+		free_token_lst(&minishell->token_lst);
+		free_cmd_lst(&minishell->cmd_lst);
+	}
+	return (status);
+}
+
 /* 
  * Parses a list of tokens and builds a linked list of commands.
  *
@@ -15,22 +26,20 @@ int	parse_tokens(t_minishell *minishell)
 	t_cmd	*cur_cmd;
 	t_token	*prev_token;
 
-	if (!minishell->token_lst)
-		return (EXIT_FAILURE);
 	minishell->cmd_lst = cmd_new(NULL);
 	if (!minishell->cmd_lst)
-		exit_minishell(EXIT_FAILURE, minishell, NULL);
+		return (parse_cleanup(minishell, EXIT_FAILURE));
 	cur_token = minishell->token_lst;
 	cur_cmd = minishell->cmd_lst;
 	while (cur_token)
 	{
 		prev_token = cur_token;
-		handle_token_type(&cur_token, &cur_cmd, minishell);
+		if (handle_token_type(&cur_token, &cur_cmd, minishell)
+			== EXIT_FAILURE)
+		return (parse_cleanup(minishell, EXIT_FAILURE));
 		if (cur_token == prev_token)
-		{
 			exit_minishell(EXIT_FAILURE, minishell, NULL);
-			return (EXIT_FAILURE);
-		}
+
 	}
 	return (EXIT_SUCCESS);
 }

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -21,7 +21,6 @@ t_parse_op	*get_parse_ops(void)
 	return (parse_ops);
 }
 
-
 /* 
  * Processes tokens based on their type using appropriate handler functions
  * - Calls handlers for redirections (`<`, `>`, `<<`, `<<`),
@@ -53,6 +52,13 @@ int	handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
 	return (EXIT_FAILURE);
 }
 
+/**
+ * Determines the error message for invalid redirection syntax.
+ * 
+ * @param token Current token (e.g., `<`, `>`, `<<`, `>>`).
+ * @return "newline" if no token follows, "|" for unexpected pipes.
+ * 
+ */
 char	*redir_error(t_token *token)
 {
 	if (!token->next)
@@ -61,4 +67,3 @@ char	*redir_error(t_token *token)
 		return ("|");
 	return (token->next->value);
 }
-

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -21,13 +21,14 @@ t_parse_op	*get_parse_ops(void)
 	return (parse_ops);
 }
 
+
 /* 
  * Processes tokens based on their type using appropriate handler functions
  * - Calls handlers for redirections (`<`, `>`, `<<`, `<<`),
  *   pipes (`|`), and words.
  * - If an unknown token is encountered, exits with an error.
  */
-void	handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
+int	handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
 	t_minishell *minishell)
 {
 	t_parse_op	*parse_ops;
@@ -41,10 +42,23 @@ void	handle_token_type(t_token **cur_token, t_cmd **cur_cmd,
 	{
 		if (parse_ops[i].type == type)
 		{
-			parse_ops[i].handler(cur_token, cur_cmd, minishell);
-			return ;
+			if (parse_ops[i].handler
+				(cur_token, cur_cmd, minishell) == EXIT_FAILURE)
+				return (EXIT_FAILURE);
+			return (EXIT_SUCCESS);
 		}
 		i++;
 	}
 	exit_minishell(EXIT_FAILURE, minishell, NULL);
+	return (EXIT_FAILURE);
 }
+
+char	*redir_error(t_token *token)
+{
+	if (!token->next)
+		return ("newline");
+	if (token->next->type == TOKEN_PIPE)
+		return ("|");
+	return (token->next->value);
+}
+

--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -27,6 +27,8 @@ t_token	*tokenizer(t_minishell *minishell)
 	while (input[i])
 	{
 		skip_whitespaces(input, &i);
+		if (!input[i])
+			break ;
 		new_token = handle_token_creation(input, &i, &unmatched_quote);
 		if (!new_token)
 			return (handle_token_error(&minishell->token_lst,


### PR DESCRIPTION
fix_redir_errors branch patch notes :
1) Fixed an error when only inserting space(s) in the minishell prompt returned the error : minishell:  :command not found. Now it returns the prompt back as expected witouth displaying errors.

How :

Added these lines isnide tokenizer.c

if (!input[i])
		      break ;

2) Fxed the known issue when by only inserting a single redirection or pipe token in the prompt displayed the appropriate error message, but exited the shell afterwards.

How:

Added 2 functions pipe_error & redir_error in order to identify the appropriate error message. All functions inside /parser/handlers/ were refactored from void to int in order to have returning values and call the new functions accordingly and also they now make appropriatge usage of the existing put_error function.
In addition,  a new fucntion parse_cleanup was introduced in caee only parsing fails.

3) Fixed the heredoc issue where in case the user presses CTRL + D during the interactive mode, there was a segmentation fault and leak errors. Now the prompt will display an appropriate message that aligns with bash.

How :

Inserted these lines inside read_heredoc :

		if (!line)
		{
			set_errno(0);
			put_error("warning: here-document at line %d delimited by "
				"end of file (wanted `%s')", cmd->heredoc_start,
				cmd->heredoc_del);
			break ;
		}


As bash also returns inside the message the line number where the heredoc command was introduced (not inside interactive mode, but rather the exact line when hererdoc command was typed), new elements were added inside the following struscts :


typedef struct s_cmd
int				heredoc_start;



typedef struct s_minishell
int			input_line;


Now, set_input function will also have this line inside, in order to count each line for each input :
`minishell->input_line++;'

handle_redir_heredoc will store line number inc command :
`(*cur_cmd)->heredoc_start = minishell->input_line;`

And lastly it will be called inside the error message inside read_heredoc if applicable :


put_error("warning: here-document at line %d delimited by "
				"end of file (wanted `%s')", cmd->heredoc_start,
				cmd->heredoc_del);

				
process_heredod fucntion was also needed to be modified in order to cleann up the heredoc tmp files, as they would remain in case of the process being terminated with CTRL + D.

Please make sure to make tests and give me feedback :)







